### PR TITLE
Codice fiscale, esperienze lavorative

### DIFF
--- a/ProgettoIngegneria/src/main/java/com/example/progettoingegneria/Dipendente.java
+++ b/ProgettoIngegneria/src/main/java/com/example/progettoingegneria/Dipendente.java
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Crea oggetti che rappresentano un dipendente.
@@ -185,29 +184,6 @@ public class Dipendente extends Persona{
      */
     public boolean isDipendente(){
         return true;
-    }
-
-    /**
-     * Verifica se this e' uguale a o
-     * @param o Oggetto con cui confrontare this
-     * @return true se this e' uguale a o, false altrimenti
-     */
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
-        Dipendente that = (Dipendente) o;
-        return username.equals(that.username) && password.equals(that.password);
-    }
-
-    /**
-     * Restituisce hash
-     * @return hash
-     */
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), username, password);
     }
 
     /**

--- a/ProgettoIngegneria/src/main/java/com/example/progettoingegneria/EsperienzaLavorativa.java
+++ b/ProgettoIngegneria/src/main/java/com/example/progettoingegneria/EsperienzaLavorativa.java
@@ -41,6 +41,9 @@ public class EsperienzaLavorativa {
     /** Retribuzione lorda giornaliera */
     private int retribuzioneLordaGiornaliera;
 
+    /** ID dell'esperienza lavorativa */
+    private int id;
+
     /** Validatore per l'esperienza lavorativa */
     @JsonIgnore
     private final Validator<EsperienzaLavorativa> validator = ValidatorBuilder.<EsperienzaLavorativa>of()
@@ -265,6 +268,22 @@ public class EsperienzaLavorativa {
     }
 
     /**
+     * Restituisce identificativo dell'esperienza di lavoro del lavoratore
+     * @return ID esperienza lavorativa
+     */
+    protected int getId(){
+        return this.id;
+    }
+
+    /**
+     * Imposta identificativo dell'esperienza lavorativa
+     * @param id Identificativo dell'esperienza lavorativa
+     */
+    protected void setId(int id){
+        this.id = id;
+    }
+
+    /**
      * Restituisce le violazioni rilevate dal validatore delle esperienze lavorative.
      * @return Violazioni nelle proprieta' oggetto
      */
@@ -295,5 +314,21 @@ public class EsperienzaLavorativa {
     @Override
     public int hashCode() {
         return Objects.hash(inizioPeriodoLavorativo, finePeriodoLavorativo, nomeAzienda, mansioniSvolte, luogoLavoro, retribuzioneLordaGiornaliera);
+    }
+
+    /**
+     * Restituisce stringa con tutte le proprieta' dell'oggetto
+     * @return Stringa con tutte le proprieta' dell'oggetto
+     */
+    @Override
+    public String toString() {
+        return "EsperienzaLavorativa{" +
+            "inizioPeriodoLavorativo=" + inizioPeriodoLavorativo +
+            ", finePeriodoLavorativo=" + finePeriodoLavorativo +
+            ", nomeAzienda='" + nomeAzienda + '\'' +
+            ", mansioniSvolte=" + mansioniSvolte +
+            ", luogoLavoro='" + luogoLavoro + '\'' +
+            ", retribuzioneLordaGiornaliera=" + retribuzioneLordaGiornaliera +
+            '}';
     }
 }

--- a/ProgettoIngegneria/src/main/java/com/example/progettoingegneria/EsperienzaLavorativa.java
+++ b/ProgettoIngegneria/src/main/java/com/example/progettoingegneria/EsperienzaLavorativa.java
@@ -42,7 +42,7 @@ public class EsperienzaLavorativa {
     private int retribuzioneLordaGiornaliera;
 
     /** ID dell'esperienza lavorativa */
-    private int id;
+    private int id = -1;
 
     /** Validatore per l'esperienza lavorativa */
     @JsonIgnore

--- a/ProgettoIngegneria/src/main/java/com/example/progettoingegneria/Lavoratore.java
+++ b/ProgettoIngegneria/src/main/java/com/example/progettoingegneria/Lavoratore.java
@@ -13,12 +13,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Classe che rappresenta un lavoratore.
  */
-@JsonIgnoreProperties(value={ "tipo", "isAdmin", "admin", "dipendente" }, allowGetters=true)  // ignora "tipo" quando si converte JSON in oggetto
+@JsonIgnoreProperties(value={ "tipo", "isAdmin", "admin", "dipendente", "uniqueEsperienzaLavorativaId"}, allowGetters=true)  // ignora "tipo" quando si converte JSON in oggetto
 public class Lavoratore extends Persona{
     /** Tipo di persona nel sistema: utile per l'output JSON */
     private final String tipo = "lavoratore";
@@ -26,7 +25,7 @@ public class Lavoratore extends Persona{
     /** Indirizzo di residenza */
     private String indirizzoResidenza;
     /** Insieme di esperienze lavorative del lavoratore */
-    private Collection<EsperienzaLavorativa> esperienzeLavorative;
+    private Collection<EsperienzaLavorativa> esperienzeLavorative = new ArrayList<>();
     /** Insieme di lingue parlate dal lavoratore */
     private Collection<Lingua> lingueParlate;
     /** Insieme di patenti possedute dal lavoratore */
@@ -37,6 +36,9 @@ public class Lavoratore extends Persona{
     private Collection<PeriodoDisponibilita> periodiDisponibilita;
     /** Insieme di recapiti da usare in caso di emergenza */
     private Collection<RecapitoUrgenza> recapitiUrgenze;
+
+    /** Identificativo univoco esperienza lavorativa */
+    private int uniqueEsperienzaLavorativaId = 0;
 
     /** Validatore dati di un lavoratore */
     private static final Validator<Lavoratore> validator = ValidatorBuilder.<Lavoratore>of()
@@ -185,11 +187,19 @@ public class Lavoratore extends Persona{
     /**
      * Imposta esperienze lavorative.
      * @param esperienzeLavorative Esperienze lavorative
+     * @return true se tutte le esperienze lavorative sono state aggiunte correttamente
      */
-    protected void setEsperienzeLavorative(Collection<EsperienzaLavorativa> esperienzeLavorative){
+    protected boolean setEsperienzeLavorative(Collection<EsperienzaLavorativa> esperienzeLavorative){
         if (esperienzeLavorative == null)
             throw new IllegalArgumentException("esperienzeLavorative non puo' essere null");
-        this.esperienzeLavorative = esperienzeLavorative;
+
+        boolean success = true;
+        for (EsperienzaLavorativa esperienzaLavorativa: esperienzeLavorative) {
+            if (!addEsperienzaLavorativa(esperienzaLavorativa)){
+                success = false;
+            }
+        }
+        return success;
     }
 
     /**
@@ -201,6 +211,9 @@ public class Lavoratore extends Persona{
         if (esperienzaLavorativa == null)
             throw new IllegalArgumentException("esperienzaLavorativa non puo' essere null");
 
+        esperienzaLavorativa.setId(uniqueEsperienzaLavorativaId);
+        uniqueEsperienzaLavorativaId++;
+
         if (!this.esperienzeLavorative.contains(esperienzaLavorativa)) {
             return this.esperienzeLavorative.add(esperienzaLavorativa);
         }
@@ -209,14 +222,16 @@ public class Lavoratore extends Persona{
 
     /**
      * Rimuove una esperienza lavorativa
-     * @param esperienzaLavorativa Esperienza lavorativa
+     * @param esperienzaLavorativaId Identificativo esperienza lavorativa
      * @return true se esperienzaLavorativa e' stata rimossa
      */
-    protected boolean removeEsperienzaLavorativa(EsperienzaLavorativa esperienzaLavorativa){
-        if (esperienzaLavorativa == null)
-            throw new IllegalArgumentException("esperienzaLavorativa non puo' essere null");
-
-        return this.esperienzeLavorative.remove(esperienzaLavorativa);
+    protected boolean removeEsperienzaLavorativa(int esperienzaLavorativaId){
+        for (EsperienzaLavorativa esperienzaLavorativa : esperienzeLavorative) {
+            if (esperienzaLavorativa.getId() == esperienzaLavorativaId){
+                return this.esperienzeLavorative.remove(esperienzaLavorativa);
+            }
+        }
+        return false;
     }
 
     /**
@@ -472,28 +487,5 @@ public class Lavoratore extends Persona{
     @Override
     public boolean isDipendente(){
         return false;
-    }
-
-    /**
-     * Verifica se this e' uguale a o
-     * @param o Oggetto con cui confrontare this
-     * @return true se this e' uguale a o, false altrimenti
-     */
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
-        Lavoratore that = (Lavoratore) o;
-        return automunito == that.automunito && indirizzoResidenza.equals(that.indirizzoResidenza) && esperienzeLavorative.equals(that.esperienzeLavorative) && lingueParlate.equals(that.lingueParlate) && patenti.equals(that.patenti) && periodiDisponibilita.equals(that.periodiDisponibilita) && recapitiUrgenze.equals(that.recapitiUrgenze);
-    }
-
-    /**
-     * Restituisce hash
-     * @return hash
-     */
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), indirizzoResidenza, esperienzeLavorative, lingueParlate, patenti, automunito, periodiDisponibilita, recapitiUrgenze);
     }
 }

--- a/ProgettoIngegneria/src/main/java/com/example/progettoingegneria/Main.java
+++ b/ProgettoIngegneria/src/main/java/com/example/progettoingegneria/Main.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 public class Main {
 
-    public static void main(String[] args) throws JsonProcessingException{
+    public static void main(String[] args) throws IOException, URISyntaxException {
 
         System.out.println("OGGETTI CREATI VIA CODICE:\n");
         Dipendente d = Dipendente.of(
@@ -111,23 +111,36 @@ public class Main {
 
         System.out.println("\nMANAGEMENT SYSTEM:\n");
 
-        ManagementSystem ms = null;
-        try {
-            ms = ManagementSystem.getInstance();
-            ms.login("mario", "secret");
-            System.out.println("Aggiungi dipendente");
-            ms.addDipendente(d);
-            System.out.println("Aggiungi lavoratore");
-            ms.addLavoratore(vgoulette_l);
-        }
-        catch (IOException e){
-            System.out.println(e);
-        }
-        catch (URISyntaxException e){
-            System.out.println(e);
-        }
+        ManagementSystem ms = ManagementSystem.getInstance();
+        ms.login("mario", "secret");
+        System.out.println("Aggiungi dipendente");
+        ms.addDipendente(d);
+        ms.addDipendente(mcurley_d);
+        System.out.println("Aggiungi lavoratore");
+        ms.addLavoratore(vgoulette_l);
+        ms.addEsperienzaLavorativa(vgoulette_l.getCodiceFiscale(), EsperienzaLavorativa.of(
+            LocalDate.of(2000, 1, 2),
+            LocalDate.of(2000, 2, 2),
+            "Nome",
+            List.of("Architetto"),
+            "luogo",
+            123
+        ));
+        Lavoratore t = (Lavoratore) ms.getLavoratori().toArray()[0];
+        EsperienzaLavorativa e = (EsperienzaLavorativa) t.getEsperienzeLavorative().toArray()[1];
+        System.out.println("ID: " + e.getId());
+        System.out.println(ms);
 
-        if (ms != null)
-            System.out.println(ms);
+        System.out.println("Dipendenti nel MS: " + ms.getDipendenti());
+        System.out.println("Lavoratori nel MS: " + ms.getLavoratori());
+        for (Lavoratore lavoratore: ms.getLavoratori()){
+            System.out.println(lavoratore);
+            for (EsperienzaLavorativa el: lavoratore.getEsperienzeLavorative()) {
+                System.out.println(el);
+                System.out.println("ID: " + el.getId());
+                System.out.println("");
+            }
+            System.out.println("------------------------------------");
+        }
     }
 }

--- a/ProgettoIngegneria/src/main/java/com/example/progettoingegneria/ManagementSystem.java
+++ b/ProgettoIngegneria/src/main/java/com/example/progettoingegneria/ManagementSystem.java
@@ -663,6 +663,13 @@ public class ManagementSystem {
             );
         }
 
+        if (esperienzaLavorativa.validate().size() > 0 ) {
+            return new ManagementSystemResponse(
+                ManagementSystemStatus.INVALID_INPUT,
+                esperienzaLavorativa.validate()
+            );
+        }
+
         Dipendente utente = (Dipendente) loggedInUser;
 
         for (Lavoratore lavoratore: this.lavoratori) {
@@ -671,13 +678,6 @@ public class ManagementSystem {
             }
 
             // trovato lavoratore
-            if (esperienzaLavorativa.validate().size() > 0 ) {
-                return new ManagementSystemResponse(
-                    ManagementSystemStatus.INVALID_INPUT,
-                    esperienzaLavorativa.validate()
-                );
-            }
-
             if (!lavoratore.addEsperienzaLavorativa(esperienzaLavorativa)) {
                 return new ManagementSystemResponse(
                     ManagementSystemStatus.ACTION_FAILED,

--- a/ProgettoIngegneria/src/main/java/com/example/progettoingegneria/ManagementSystemResponse.java
+++ b/ProgettoIngegneria/src/main/java/com/example/progettoingegneria/ManagementSystemResponse.java
@@ -4,32 +4,51 @@ import java.util.Collection;
 
 public class ManagementSystemResponse {
 
-    private ManagementSystemStatus status;
-    private Collection<String> details;
+    /** Stato della richiesta */
+    private final ManagementSystemStatus status;
+    /** Dettagli sullo stato */
+    private final Collection<String> details;
 
+    /**
+     * Crea la risposta ad una richiesta effettuata da un utente del Management System
+     * @param status Stato della richiesta
+     * @param details Dettagli sullo stato
+     */
     public ManagementSystemResponse(ManagementSystemStatus status, Collection<String> details) {
         this.status = status;
         this.details = details;
     }
 
+    /**
+     * Restituisci stato del management system
+     * @return Stato del management system
+     */
     public ManagementSystemStatus getStatus() {
         return status;
     }
 
+    /**
+     * Restituisci lista di messaggi di errore relativi all'ultima richiesta
+     * @return Lista di messaggi di errore
+     */
     public Collection<String> getDetails() {
         return details;
     }
 
+    /**
+     * Restituisce lo stato della risposta alla richiesta seguito dalla lista dei dettagli
+     * @return Stato della risposta con lista dei dettagli
+     */
     @Override
     public String toString() {
-        String res = "[" + this.status + "]";
+        StringBuilder res = new StringBuilder("[" + this.status + "] ");
 
         for (int i = 0; i < details.size(); i++) {
-            res += details.toArray()[i];
+            res.append(details.toArray()[i]);
 
             if (i < details.size()-1)
-                res += ", ";
+                res.append(", ");
         }
-        return res;
+        return res.toString();
     }
 }

--- a/ProgettoIngegneria/src/main/java/com/example/progettoingegneria/Persona.java
+++ b/ProgettoIngegneria/src/main/java/com/example/progettoingegneria/Persona.java
@@ -9,7 +9,6 @@ package com.example.progettoingegneria;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Supplier;
 
 import am.ik.yavi.builder.ValidatorBuilder;
@@ -76,7 +75,7 @@ public abstract class Persona implements PersonaInterface {
         )
         .constraint(Persona::getNazionalita, "nazionalita'",
             c -> c.notBlank()              // non puo': essere null, contenere solo spazi, essere vuota
-                .lessThanOrEqual(20)       // lunghezza massima 20: 17 e' il massimo qui https://www.dizy.com/it/lista/6017297130979328
+                .lessThanOrEqual(50)       // lunghezza massima 50: 17 e' il massimo qui https://www.dizy.com/it/lista/6017297130979328
         )
         .constraint(Persona::getIndirizzoEmail, "email",
             c -> c.notBlank()              // non puo': essere null, contenere solo spazi, essere vuota
@@ -331,7 +330,7 @@ public abstract class Persona implements PersonaInterface {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Persona persona = (Persona) o;
-        return nome.equals(persona.nome) && cognome.equals(persona.cognome) && luogoNascita.equals(persona.luogoNascita) && dataNascita.equals(persona.dataNascita) && nazionalita.equals(persona.nazionalita) && indirizzoEmail.equals(persona.indirizzoEmail) && numeroTelefono.equals(persona.numeroTelefono);
+        return this.codiceFiscale.equals(persona.codiceFiscale);
     }
 
     /**
@@ -340,7 +339,7 @@ public abstract class Persona implements PersonaInterface {
      */
     @Override
     public int hashCode() {
-        return Objects.hash(nome, cognome, luogoNascita, dataNascita, nazionalita, indirizzoEmail, numeroTelefono);
+        return this.codiceFiscale.hashCode();
     }
 
     @Override

--- a/ProgettoIngegneria/src/main/resources/com/example/progettoingegneria/admin.json
+++ b/ProgettoIngegneria/src/main/resources/com/example/progettoingegneria/admin.json
@@ -9,6 +9,7 @@
         "numeroTelefono":"045045045",
         "tipo":"admin",
         "username":"mario",
-        "password":"secret"
+        "password":"secret",
+        "codiceFiscale":"ABCD"
     }
 ]

--- a/ProgettoIngegneria/src/test/java/com/example/progettoingegneria/TestManagementSystem.java
+++ b/ProgettoIngegneria/src/test/java/com/example/progettoingegneria/TestManagementSystem.java
@@ -7,13 +7,12 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.ZoneId;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import com.github.javafaker.Faker;
 
+import static java.util.Objects.nonNull;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.AfterEach;
@@ -28,9 +27,14 @@ public class TestManagementSystem {
     File lavoratoriFile = Paths.get(resourcePath, "lavoratori.json").toFile();
     File adminFile = Paths.get(resourcePath, "admin.json").toFile();
 
+    /**
+     * Dopo l'inizio e la fine di ogni test resetta i file JSON e il management system.
+     * @throws IOException
+     * @throws URISyntaxException
+     */
     @BeforeEach
     @AfterEach
-    void setUp() throws IOException {
+    void setUp() throws IOException, URISyntaxException {
         List<String> emptyJSON = Arrays.asList("[]");
         List<String> initAdminJSON = Arrays.asList(
             "[",
@@ -44,15 +48,93 @@ public class TestManagementSystem {
             "    \"numeroTelefono\":\"045045045\",",
             "    \"tipo\":\"admin\",",
             "    \"username\":\"mario\",",
-            "    \"password\":\"secret\"",
+            "    \"password\":\"secret\",",
+            "    \"codiceFiscale\":\"ABCD\"",
             "    }",
             "]"
         );
         Files.write(dipendentiFile.toPath(), emptyJSON, StandardCharsets.UTF_8);
         Files.write(lavoratoriFile.toPath(), emptyJSON, StandardCharsets.UTF_8);
         Files.write(adminFile.toPath(), initAdminJSON, StandardCharsets.UTF_8);
+
+        ManagementSystem ms = ManagementSystem.getInstance(resourcePath);
+        ms.logout();
+        ManagementSystem.deleteInstance();
     }
 
+    /** Numeri di telefono senza duplicati */
+    private final Collection<String> telephoneNumbers = new ArrayList<>();
+    /** Codici fiscali senza duplicati */
+    private final Collection<String> codiciFiscali = new ArrayList<>();
+    /** Password senza duplicati */
+    private final Collection<String> passwords = new ArrayList<>();
+
+    /**
+     * Genera una password univoca che ha tra i 15 e i 20 caratteri e
+     * che include lettere maiuscole, minuscole, caratteri speciali e numeri.
+     * @return Password univoca
+     */
+    private String generateStrongPassword() {
+        var password = new Faker().internet().password(15, 20, true, true, true);
+        if (isPasswordValid(password) && (!passwords.contains(password))) {
+            passwords.add(password);
+            return password;
+        }
+        return generateStrongPassword();
+    }
+
+    /**
+     * Si assicura che una password generata sia valida.
+     *
+     * La password deve avere:
+     * - tra i 15 e i 20 caratteri
+     * - almeno una lettera maiuscola e una minuscola
+     * - almeno un carattere speciale tra $, &, @, #
+     * - almeno un numero
+     *
+     * @param password Password da validare
+     * @return true se la password e' valida, false altrimenti
+     */
+    private boolean isPasswordValid(String password) {
+        return nonNull(password) && password.length() >= 15 && password.length() <= 20 &&
+            password.chars().anyMatch(Character::isDigit) &&
+            password.chars().anyMatch(Character::isLowerCase) &&
+            password.chars().anyMatch(Character::isUpperCase) &&
+            (password.chars().anyMatch(c -> c == '$') || password.chars().anyMatch(c -> c == '&') || password.chars().anyMatch(c -> c == '@') || password.chars().anyMatch(c -> c == '#'));
+    }
+
+    /**
+     * Genera numero di telefono univoco che ha meno di 20 cifre.
+     * @return Numero di telefono
+     */
+    private String generateTelephoneNumber(){
+        String telephoneNumber = faker.phoneNumber().phoneNumber();
+
+        while (telephoneNumber.length() > 20 || telephoneNumbers.contains(telephoneNumber)){
+            telephoneNumber = faker.phoneNumber().phoneNumber();
+        }
+        telephoneNumbers.add(telephoneNumber);
+        return telephoneNumber;
+    }
+
+    /**
+     * Genera codice fiscale univoco
+     * @return Codice fiscale
+     */
+    private String generateCodiceFiscale(){
+        String codiceFiscale = faker.idNumber().ssnValid();
+        while (codiciFiscali.contains(codiceFiscale)){
+            codiceFiscale = faker.idNumber().ssnValid();
+        }
+        codiciFiscali.add(codiceFiscale);
+        return codiceFiscale;
+    }
+
+    /**
+     * Si assicura che il sistema crei un solo management system
+     * @throws IOException
+     * @throws URISyntaxException
+     */
     @Test
     void testOneInstance() throws IOException, URISyntaxException {
         // se provo a creare due istanze mi aspetto di crearne una sola
@@ -61,6 +143,11 @@ public class TestManagementSystem {
         assertEquals(ms, ms2);
     }
 
+    /**
+     * Effettua test di login e logout
+     * @throws IOException
+     * @throws URISyntaxException
+     */
     @Test
     void testLoginAndLogout() throws IOException, URISyntaxException {
         ManagementSystem ms = ManagementSystem.getInstance(resourcePath);
@@ -74,8 +161,12 @@ public class TestManagementSystem {
         // provo a entrare inserendo valori nulli al posto di inserire username e password: dovrebbe dare errore
         assertThrows(IllegalArgumentException.class, () -> ms.login(null, null));
 
-        // provo ad entrare con password errate: non dovrei riuscire ad accedere e quindi nessun utente e' autenticato
+        // provo ad entrare con username e password errati: non dovrei riuscire ad accedere e quindi nessun utente e' autenticato
         assertFalse(ms.login("", ""));
+        assertNull(ms.getLoggedInUser());
+
+        // provo a entrare con password errata: non dovrei riuscire ad accedere
+        assertFalse(ms.login("mario", ""));
         assertNull(ms.getLoggedInUser());
 
         // provo a inserire username e password di un utente esistente: dovrei essere in grado di entrare
@@ -87,6 +178,11 @@ public class TestManagementSystem {
         assertNull(ms.getLoggedInUser());
     }
 
+    /**
+     * Prova ad aggiungere e togliere lavoratori dal sistema
+     * @throws IOException
+     * @throws URISyntaxException
+     */
     @Test
     void testAddAndRemoveLavoratori() throws IOException, URISyntaxException {
 
@@ -99,7 +195,7 @@ public class TestManagementSystem {
             faker.date().future(10, TimeUnit.DAYS).toInstant().atZone(ZoneId.systemDefault()).toLocalDate(),
             faker.address().country(),
             faker.internet().emailAddress(),
-            faker.phoneNumber().phoneNumber(),
+            generateTelephoneNumber(),
             faker.address().streetAddress(),
             List.of(),
             List.of(),
@@ -107,7 +203,7 @@ public class TestManagementSystem {
             false,
             List.of(),
             List.of(),
-            faker.idNumber().ssnValid()
+            generateCodiceFiscale()
         );
 
         // crea data attuale e sottraici 20 anni
@@ -121,7 +217,7 @@ public class TestManagementSystem {
             faker.date().past(365*10, TimeUnit.DAYS, twentyYearsAgo).toInstant().atZone(ZoneId.systemDefault()).toLocalDate(),
             faker.address().country(),
             faker.internet().emailAddress(),
-            faker.phoneNumber().phoneNumber(),
+            generateTelephoneNumber(),
             faker.address().streetAddress(),
             List.of(),
             List.of(),
@@ -132,11 +228,11 @@ public class TestManagementSystem {
                 RecapitoUrgenza.of(
                     faker.name().firstName(),
                     faker.name().lastName(),
-                    faker.phoneNumber().phoneNumber(),
+                    generateTelephoneNumber(),
                     faker.internet().emailAddress()
                 )
             ),
-            faker.idNumber().ssnValid()
+            generateCodiceFiscale()
         );
 
         // all'inizio non dovrebbe esserci nessun lavoratore
@@ -164,6 +260,7 @@ public class TestManagementSystem {
 
         // aggiungo un lavoratore con dati validi: dovrebbe essere stato inserito
         response = ms.addLavoratore(validData);
+        System.out.println(response.getDetails());
         assertEquals(ManagementSystemStatus.OK, response.getStatus());
         assertEquals(1, ms.getLavoratori().size());
 
@@ -171,5 +268,355 @@ public class TestManagementSystem {
         response = ms.addLavoratore(validData);
         assertEquals(ManagementSystemStatus.ACTION_FAILED, response.getStatus());
         assertEquals(1, ms.getLavoratori().size());
+
+        // faccio il logout
+        assertTrue(ms.logout());
+        assertNull(ms.getLoggedInUser());
+
+        // provo a rimuovere null
+        assertThrows(IllegalArgumentException.class, () -> ms.removeLavoratore(null));
+        assertEquals(1, ms.getLavoratori().size());
+
+        // provo a rimuovere un lavoratore senza aver fatto il login
+        response = ms.removeLavoratore(validData.getCodiceFiscale());
+        assertEquals(ManagementSystemStatus.NOT_LOGGED_IN, response.getStatus());
+        assertEquals(1, ms.getLavoratori().size());
+
+        // rifaccio il login
+        assertNull(ms.getLoggedInUser());
+        assertTrue(ms.login("mario", "secret"));
+        assertNotNull(ms.getLoggedInUser());
+
+        // rimuovo un lavoratore che non esiste: dovrebbe fallire
+        response = ms.removeLavoratore(generateCodiceFiscale());
+        assertEquals(ManagementSystemStatus.INVALID_INPUT, response.getStatus());
+        assertEquals(1, ms.getLavoratori().size());
+
+        // rimuovo il lavoratore esistente: mi aspetto di rimuoverlo e che non ci siano piu' lavoratori nel sistema
+        response = ms.removeLavoratore(validData.getCodiceFiscale());
+        assertEquals(ManagementSystemStatus.OK, response.getStatus());
+        assertEquals(0, ms.getLavoratori().size());
+
+        // provo a rimuovere il lavoratore di nuovo: dovrebbe fallire
+        response = ms.removeLavoratore(validData.getCodiceFiscale());
+        assertEquals(ManagementSystemStatus.INVALID_INPUT, response.getStatus());
+        assertEquals(0, ms.getLavoratori().size());
+    }
+
+    /**
+     * Prova ad aggiungere e rimuovere dipendenti
+     * @throws IOException
+     * @throws URISyntaxException
+     */
+    @Test
+    void testAddAndRemoveDipendenti() throws IOException, URISyntaxException {
+        ManagementSystem ms = ManagementSystem.getInstance(resourcePath);
+
+        Dipendente invalidData = Dipendente.of(
+            faker.name().firstName(),
+            faker.name().lastName(),
+            faker.address().streetAddress(),
+            faker.date().future(10, TimeUnit.DAYS).toInstant().atZone(ZoneId.systemDefault()).toLocalDate(),
+            faker.address().country(),
+            faker.internet().emailAddress(),
+            generateTelephoneNumber(),
+            "dipendente1",
+            "pwdinsicura",
+            generateCodiceFiscale()
+        );
+
+        // crea data attuale e sottraici 20 anni
+        Date twentyYearsAgo = new Date();
+        twentyYearsAgo.setYear(twentyYearsAgo.getYear()-20);
+
+        Dipendente validData = Dipendente.of(
+            faker.name().firstName(),
+            faker.name().lastName(),
+            faker.address().streetAddress(),
+            faker.date().past(365*10, TimeUnit.DAYS, twentyYearsAgo).toInstant().atZone(ZoneId.systemDefault()).toLocalDate(),
+            faker.address().country(),
+            faker.internet().emailAddress(),
+            generateTelephoneNumber(),
+            "dipendente2",
+            generateStrongPassword(),
+            generateCodiceFiscale()
+        );
+
+        Dipendente validData2 = Dipendente.of(
+            faker.name().firstName(),
+            faker.name().lastName(),
+            faker.address().streetAddress(),
+            faker.date().past(365*10, TimeUnit.DAYS, twentyYearsAgo).toInstant().atZone(ZoneId.systemDefault()).toLocalDate(),
+            faker.address().country(),
+            faker.internet().emailAddress(),
+            generateTelephoneNumber(),
+            "dipendente3",
+            generateStrongPassword(),
+            generateCodiceFiscale()
+        );
+
+        // all'inizio non dovrebbe esserci nessun dipendente
+        assertEquals(0, ms.getDipendenti().size());
+
+        // aggiungo un dipendente nullo: lancia un errore, non dovrebbe essere inserito
+        assertThrows(IllegalArgumentException.class, () -> ms.addDipendente(null));
+        assertEquals(0, ms.getDipendenti().size());
+
+        // aggiungo un dipendente senza accedere: non dovrebbe essere inserito
+        ManagementSystemResponse response = ms.addDipendente(invalidData);
+        assertEquals(ManagementSystemStatus.NOT_LOGGED_IN, response.getStatus());
+        assertEquals(0, ms.getDipendenti().size());
+
+        // effettuo il login
+        assertNull(ms.getLoggedInUser());
+        assertTrue(ms.login("mario", "secret"));
+        assertNotNull(ms.getLoggedInUser());
+
+        // aggiungo un dipendente con dati non validi: non dovrebbe essere inserito
+        response = ms.addDipendente(invalidData);
+        assertEquals(0, ms.getDipendenti().size());
+        assertEquals(ManagementSystemStatus.INVALID_INPUT, response.getStatus());
+        System.out.println(response.getDetails());
+
+        // aggiungo un dipendente con dati validi: dovrebbe essere stato inserito
+        response = ms.addDipendente(validData);
+        System.out.println(response.getDetails());
+        assertEquals(ManagementSystemStatus.OK, response.getStatus());
+        assertEquals(1, ms.getDipendenti().size());
+
+        // provo a ri-aggiungere lo stesso dipendente: non dovrebbe permettermelo
+        response = ms.addDipendente(validData);
+        assertEquals(ManagementSystemStatus.ACTION_FAILED, response.getStatus());
+        assertEquals(1, ms.getDipendenti().size());
+
+        // faccio il logout
+        assertTrue(ms.logout());
+        assertNull(ms.getLoggedInUser());
+
+        // provo a rimuovere null
+        assertThrows(IllegalArgumentException.class, () -> ms.removeDipendente(null));
+        assertEquals(1, ms.getDipendenti().size());
+
+        // provo a rimuovere un dipendente senza aver fatto il login
+        response = ms.removeDipendente(validData.getCodiceFiscale());
+        assertEquals(ManagementSystemStatus.NOT_LOGGED_IN, response.getStatus());
+        assertEquals(1, ms.getDipendenti().size());
+
+        // rifaccio il login
+        assertNull(ms.getLoggedInUser());
+        assertTrue(ms.login("mario", "secret"));
+        assertNotNull(ms.getLoggedInUser());
+
+        // rimuovo un dipendente che non esiste: dovrebbe fallire
+        response = ms.removeDipendente(generateCodiceFiscale());
+        assertEquals(ManagementSystemStatus.INVALID_INPUT, response.getStatus());
+        assertEquals(1, ms.getDipendenti().size());
+
+        // rimuovo il dipendente esistente: mi aspetto di rimuoverlo e che non ci siano piu' dipendenti nel sistema
+        response = ms.removeDipendente(validData.getCodiceFiscale());
+        assertEquals(ManagementSystemStatus.OK, response.getStatus());
+        assertEquals(0, ms.getDipendenti().size());
+
+        // provo a rimuovere il dipendente di nuovo: dovrebbe fallire
+        response = ms.removeDipendente(validData.getCodiceFiscale());
+        assertEquals(ManagementSystemStatus.INVALID_INPUT, response.getStatus());
+        assertEquals(0, ms.getDipendenti().size());
+
+        // inserisco di nuovo l'utente ed effettuo il login con il suo account
+        response = ms.addDipendente(validData);
+        System.out.println(response.getDetails());
+        assertEquals(ManagementSystemStatus.OK, response.getStatus());
+        assertEquals(1, ms.getDipendenti().size());
+        assertTrue(ms.logout());
+        assertNull(ms.getLoggedInUser());
+        assertTrue(ms.login(validData.getUsername(), validData.getPassword()));
+        assertNotNull(ms.getLoggedInUser());
+
+        // provo a creare un nuovo dipendente con l'account di un dipendente: non ho i permessi necessari
+        response = ms.addDipendente(validData2);
+        assertEquals(ManagementSystemStatus.PERMISSION_ERROR, response.getStatus());
+        assertEquals(1, ms.getDipendenti().size());
+
+        // provo a rimuovere un dipendente con l'account di un dipendente: non ho i permessi necessari
+        response = ms.removeDipendente(validData.getCodiceFiscale());
+        assertEquals(ManagementSystemStatus.PERMISSION_ERROR, response.getStatus());
+        assertEquals(1, ms.getDipendenti().size());
+    }
+
+    /**
+     * Prova ad aggiungere o rimuovere admin dal sistema
+     * @throws IOException
+     * @throws URISyntaxException
+     */
+    @Test
+    void testAddAndRemoveAdmin() throws IOException, URISyntaxException {
+        ManagementSystem ms = ManagementSystem.getInstance(resourcePath);
+
+        Admin invalidData = Admin.of(
+            faker.name().firstName(),
+            faker.name().lastName(),
+            faker.address().streetAddress(),
+            faker.date().future(10, TimeUnit.DAYS).toInstant().atZone(ZoneId.systemDefault()).toLocalDate(),
+            faker.address().country(),
+            faker.internet().emailAddress(),
+            generateTelephoneNumber(),
+            "admin1",
+            "pwdinsicura",
+            generateCodiceFiscale()
+        );
+
+        // crea data attuale e sottraici 20 anni
+        Date twentyYearsAgo = new Date();
+        twentyYearsAgo.setYear(twentyYearsAgo.getYear()-20);
+
+        Admin validData = Admin.of(
+            faker.name().firstName(),
+            faker.name().lastName(),
+            faker.address().streetAddress(),
+            faker.date().past(365*10, TimeUnit.DAYS, twentyYearsAgo).toInstant().atZone(ZoneId.systemDefault()).toLocalDate(),
+            faker.address().country(),
+            faker.internet().emailAddress(),
+            generateTelephoneNumber(),
+            "dipendente2",
+            generateStrongPassword(),
+            generateCodiceFiscale()
+        );
+
+        Admin validData2 = Admin.of(
+            faker.name().firstName(),
+            faker.name().lastName(),
+            faker.address().streetAddress(),
+            faker.date().past(365*10, TimeUnit.DAYS, twentyYearsAgo).toInstant().atZone(ZoneId.systemDefault()).toLocalDate(),
+            faker.address().country(),
+            faker.internet().emailAddress(),
+            generateTelephoneNumber(),
+            "dipendente4",
+            generateStrongPassword(),
+            generateCodiceFiscale()
+        );
+
+        Dipendente validDataDipendente = Dipendente.of(
+            faker.name().firstName(),
+            faker.name().lastName(),
+            faker.address().streetAddress(),
+            faker.date().past(365*10, TimeUnit.DAYS, twentyYearsAgo).toInstant().atZone(ZoneId.systemDefault()).toLocalDate(),
+            faker.address().country(),
+            faker.internet().emailAddress(),
+            generateTelephoneNumber(),
+            "dipendente3",
+            generateStrongPassword(),
+            generateCodiceFiscale()
+        );
+
+        // all'inizio dovrebbe esserci un solo admin
+        assertEquals(1, ms.getAdmins().size());
+
+        // aggiungo un admin nullo: lancia un errore, non dovrebbe essere inserito
+        assertThrows(IllegalArgumentException.class, () -> ms.addAdmin(null));
+        assertEquals(1, ms.getAdmins().size());
+
+        // aggiungo un admin senza accedere: non dovrebbe essere inserito
+        ManagementSystemResponse response = ms.addAdmin(validData);
+        assertEquals(ManagementSystemStatus.NOT_LOGGED_IN, response.getStatus());
+        assertEquals(1, ms.getAdmins().size());
+
+        // aggiungo un dipendente senza accedere: non dovrebbe essere inserito
+        response = ms.addDipendente(validDataDipendente);
+        System.out.println(response);
+        System.out.println(ms.getDipendenti());
+        assertEquals(ManagementSystemStatus.NOT_LOGGED_IN, response.getStatus());
+        assertEquals(0, ms.getDipendenti().size());
+
+        // effettuo il login
+        assertNull(ms.getLoggedInUser());
+        assertTrue(ms.login("mario", "secret"));
+        assertNotNull(ms.getLoggedInUser());
+
+        // aggiungo un admin con dati non validi: non dovrebbe essere inserito
+        response = ms.addAdmin(invalidData);
+        System.out.println(response.getDetails());
+        assertEquals(1, ms.getAdmins().size());
+        assertEquals(ManagementSystemStatus.INVALID_INPUT, response.getStatus());
+
+        // aggiungo un admin con dati validi: dovrebbe essere stato inserito
+        response = ms.addAdmin(validData);
+        System.out.println(response.getDetails());
+        assertEquals(ManagementSystemStatus.OK, response.getStatus());
+        assertEquals(2, ms.getAdmins().size());
+
+        // provo a ri-aggiungere lo stesso admin: non dovrebbe permettermelo
+        response = ms.addAdmin(validData);
+        System.out.println(response);
+        assertEquals(ManagementSystemStatus.ACTION_FAILED, response.getStatus());
+        assertEquals(2, ms.getAdmins().size());
+
+        // faccio il logout
+        assertTrue(ms.logout());
+        assertNull(ms.getLoggedInUser());
+
+        // provo a rimuovere null
+        assertThrows(IllegalArgumentException.class, () -> ms.removeAdmin(null));
+        assertEquals(2, ms.getAdmins().size());
+
+        // provo a rimuovere un admin senza aver fatto il login
+        response = ms.removeAdmin(validData.getCodiceFiscale());
+        assertEquals(ManagementSystemStatus.NOT_LOGGED_IN, response.getStatus());
+        assertEquals(2, ms.getAdmins().size());
+
+        // rifaccio il login
+        assertNull(ms.getLoggedInUser());
+        assertTrue(ms.login("mario", "secret"));
+        assertNotNull(ms.getLoggedInUser());
+
+        // rimuovo un admin che non esiste: dovrebbe fallire
+        response = ms.removeAdmin(generateCodiceFiscale());
+        assertEquals(ManagementSystemStatus.INVALID_INPUT, response.getStatus());
+        assertEquals(2, ms.getAdmins().size());
+
+        // provo a rimuovere me stesso: dovrebbe fallire
+        String defaultAdminCodiceFiscale = ms.getLoggedInUser().getCodiceFiscale();
+        response = ms.removeAdmin(defaultAdminCodiceFiscale);
+        assertEquals(ManagementSystemStatus.REMOVE_SELF, response.getStatus());
+        assertEquals(2, ms.getAdmins().size());
+
+        // faccio il login con il nuovo admin ed elimino l'account admin iniziale
+        ms.logout();
+        ms.login(validData.getUsername(), validData.getPassword());
+        response = ms.removeAdmin(defaultAdminCodiceFiscale);
+        assertEquals(ManagementSystemStatus.OK, response.getStatus());
+        assertEquals(1, ms.getAdmins().size());
+
+        // provo di nuovo a eliminare me stesso: dovrebbe fallire
+        response = ms.removeAdmin(ms.getLoggedInUser().getCodiceFiscale());
+        assertEquals(ManagementSystemStatus.REMOVE_SELF, response.getStatus());
+        assertEquals(1, ms.getAdmins().size());
+
+        // provo a creare un nuovo dipendente con l'account di un admin: dovrebbe funzionare
+        response = ms.addDipendente(validDataDipendente);
+        assertEquals(ManagementSystemStatus.OK, response.getStatus());
+        assertEquals(1, ms.getDipendenti().size());
+
+        // esco dall'account admin ed entro nell'account dipendente
+        ms.logout();
+        ms.login(validDataDipendente.getUsername(), validDataDipendente.getPassword());
+
+        // provo a rimuovere un admin con l'account di un dipendente: non ho i permessi richiesti
+        response = ms.removeAdmin(validData.getCodiceFiscale());
+        assertEquals(ManagementSystemStatus.PERMISSION_ERROR, response.getStatus());
+        assertEquals(1, ms.getAdmins().size());
+
+        // provo ad aggiungere un admin con l'account di un dipendente: non ho i permessi richiesti
+        response = ms.addAdmin(validData2);
+        assertEquals(ManagementSystemStatus.PERMISSION_ERROR, response.getStatus());
+        assertEquals(1, ms.getAdmins().size());
+
+        // ri-effettuo il login con l'account admin
+        ms.logout();
+        ms.login(validData.getUsername(), validData.getPassword());
+
+        // provo a rimuovere un dipendente con l'account di un admin: dovrebbe funzionare
+        response = ms.removeDipendente(validDataDipendente.getCodiceFiscale());
+        assertEquals(ManagementSystemStatus.OK, response.getStatus());
+        assertEquals(0, ms.getDipendenti().size());
     }
 }

--- a/ProgettoIngegneria/src/test/java/com/example/progettoingegneria/TestManagementSystem.java
+++ b/ProgettoIngegneria/src/test/java/com/example/progettoingegneria/TestManagementSystem.java
@@ -1,3 +1,8 @@
+/**
+ * Esegue unit test sul management system.
+ *
+ * TODO: testare i metodi che si occupano di aggiungere, eliminare e modificare le esperienze lavorative dei lavoratori
+ */
 package com.example.progettoingegneria;
 
 import java.io.File;

--- a/ProgettoIngegneria/src/test/resources/com/example/progettoingegneria/admin.json
+++ b/ProgettoIngegneria/src/test/resources/com/example/progettoingegneria/admin.json
@@ -9,6 +9,7 @@
     "numeroTelefono":"045045045",
     "tipo":"admin",
     "username":"mario",
-    "password":"secret"
+    "password":"secret",
+    "codiceFiscale":"ABCD"
     }
 ]


### PR DESCRIPTION
* I metodi per rimuovere persone (lavoratori, dipendenti, admin) ora utilizzano il codice fiscale come parametro per la selezione
* Aggiunto identificativo alle esperienze lavorative per poter specificare su quale esperienza lavorativa eseguire azioni
* Aggiunti metodi per aggiungere, eliminare e modificare esperienze lavorative